### PR TITLE
Interface between codegen and shrinking algorithm

### DIFF
--- a/cmd/loader.go
+++ b/cmd/loader.go
@@ -6,6 +6,8 @@ package cmd
 import (
 	"github.com/golang/glog"
 	"github.com/koki/shorthand/inspect"
+	"github.com/koki/shorthand/mapping"
+	"github.com/kr/pretty"
 	"golang.org/x/tools/go/loader"
 
 	// We're importing "v1" so it and its dependencies are added to vendor/.
@@ -56,6 +58,7 @@ func loadAndPrint(typeName string) {
 
 	// Test the traversal context by printing all fields "recursively".
 	for _, context := range contexts {
-		context.Print(0)
+		pretty.Println(mapping.DeepParseType(context))
+		//context.Print(0)
 	}
 }

--- a/cmd/mapping.go
+++ b/cmd/mapping.go
@@ -4,7 +4,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/koki/shorthand/inspect"
 	"github.com/koki/shorthand/mapping"
-	"github.com/kr/pretty"
 	"golang.org/x/tools/go/loader"
 
 	// We're importing "v1" so it and its dependencies are added to vendor/.
@@ -56,7 +55,9 @@ func loadAndMap(typeName string) {
 	// Test the traversal context by printing all fields "recursively".
 	for _, context := range contexts {
 		t := mapping.DeepParseType(context)
-		pretty.Println(t.IdentityMapping([]mapping.Choice{}))
+		mapping := t.IdentityMapping([]mapping.Choice{})
+		mapping.Shrink()
+		mapping.Print(0)
 		//context.Print(0)
 	}
 }

--- a/cmd/mapping.go
+++ b/cmd/mapping.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"github.com/golang/glog"
+	"github.com/koki/shorthand/inspect"
+	"github.com/koki/shorthand/mapping"
+	"github.com/kr/pretty"
+	"golang.org/x/tools/go/loader"
+
+	// We're importing "v1" so it and its dependencies are added to vendor/.
+	// This package doesn't need "v1" to build, but it does need access
+	//   to the source files at runtime.
+	// TODO(ublubu): Make sure "go/loader" is configured to find the vendor
+	//   folder even if we run "shorthand" outside its source directory.
+	_ "k8s.io/api/core/v1"
+)
+
+// load a package and traverse all its types.
+func loadAndMap(typeName string) {
+	var conf loader.Config
+
+	// We're just loading "v1" (and then all its dependencies).
+	conf.Import("k8s.io/api/core/v1")
+	program, err := conf.Load()
+
+	// If we're missing dependencies or our "v1" is otherwise broken, quit.
+	if err != nil {
+		glog.Error(err)
+		return
+	}
+
+	initialPackages := program.InitialPackages()
+	if len(initialPackages) == 0 {
+		glog.Errorf("go/loader succeeded, but no packages loaded. weird.")
+		return
+	}
+
+	v1pkg := initialPackages[0]
+	var contexts []*inspect.Context
+
+	if len(typeName) > 0 {
+		// Create a traversal context for the named type.
+		context := inspect.ContextForPackageAndType(
+			program, v1pkg, typeName)
+		if context == nil {
+			glog.Errorf("couldn't find v1 type %s", typeName)
+			return
+		}
+
+		contexts = []*inspect.Context{context}
+	} else {
+		// Create a traversal context for each type definition in "v1".
+		contexts = inspect.ContextsForPackage(program, v1pkg)
+	}
+
+	// Test the traversal context by printing all fields "recursively".
+	for _, context := range contexts {
+		t := mapping.DeepParseType(context)
+		pretty.Println(t.IdentityMapping([]mapping.Choice{}))
+		//context.Print(0)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,19 @@ var printCmd = &cobra.Command{
 	},
 }
 
+var shrinkCmd = &cobra.Command{
+	Use:   "shrink [optional: v1 type name, e.g. Pod]",
+	Short: "shrink a k8s v1 type",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) > 0 {
+			loadAndMap(args[0])
+		} else {
+			loadAndMap("")
+		}
+	},
+}
+
 var playCmd = &cobra.Command{
 	Use:   "play",
 	Short: "do some random stuff (development purposes only)",
@@ -32,5 +45,5 @@ var playCmd = &cobra.Command{
 }
 
 func init() {
-	RootCmd.AddCommand(printCmd, playCmd)
+	RootCmd.AddCommand(printCmd, playCmd, shrinkCmd)
 }

--- a/mapping/mapping.go
+++ b/mapping/mapping.go
@@ -1,0 +1,128 @@
+package mapping
+
+import (
+	//"go/ast"
+
+	"github.com/koki/shorthand/inspect"
+)
+
+/*
+
+When mapping to a struct, we map each field from a path into another object.
+When mapping to a collection, we map each item from another collection.
+When mapping to a pointer, we map from a set of pointers.
+  If all are nil, then map to nil.
+
+
+*/
+
+type AccessType struct {
+	Whole TypeWrapper
+	Part  TypeWrapper
+}
+
+type Access struct {
+	AccessType
+	Accessor Accessor
+}
+
+type Accessor interface {
+	getAccessor() Accessor
+}
+
+type FieldAccess struct {
+	Name string
+}
+
+type MapAccess struct {
+}
+
+type SliceAccess struct {
+}
+
+type PointerAccess struct {
+}
+
+type MappingAccess struct {
+	Mapping Mapping
+}
+
+type AccessPath struct {
+	Segments []Access
+}
+
+type MappingDefinition interface {
+	getMappingDefinition() MappingDefinition
+}
+
+type MappedStruct struct {
+	Fields map[FieldAccess]AccessPath
+}
+
+type MappedMap struct {
+}
+
+type MappedSlice struct {
+}
+
+type MappedSimplePointer struct {
+	Field AccessPath
+}
+
+type MappedStructPointer struct {
+	Fields map[FieldAccess]AccessPath
+}
+
+type Mapping struct {
+	From       TypeWrapper
+	To         TypeWrapper
+	Definition MappingDefinition
+}
+
+func IdentityMappingFor(context *inspect.Context) *Mapping {
+	/*
+		rootType := RootType(context)
+		mapping := &Mapping{From: rootType, To: rootType}
+			switch root := context.TypeSpec.Type {
+				case *
+			}
+	*/
+
+	return nil
+}
+
+func (d *MappedStruct) getMappingDefinition() MappingDefinition {
+	return d
+}
+
+func (d *MappedMap) getMappingDefinition() MappingDefinition {
+	return d
+}
+
+func (d *MappedSlice) getMappingDefinition() MappingDefinition {
+	return d
+}
+
+func (d *MappedSimplePointer) getMappingDefinition() MappingDefinition {
+	return d
+}
+
+func (d *MappedStructPointer) getMappingDefinition() MappingDefinition {
+	return d
+}
+
+func (a *FieldAccess) getAccessor() Accessor {
+	return a
+}
+
+func (a *MapAccess) getAccessor() Accessor {
+	return a
+}
+
+func (a *SliceAccess) getAccessor() Accessor {
+	return a
+}
+
+func (a *PointerAccess) getAccessor() Accessor {
+	return a
+}

--- a/mapping/print.go
+++ b/mapping/print.go
@@ -1,0 +1,86 @@
+package mapping
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+// These (and init()) are just for formatting the Print methods.
+var maxDepth = 40
+var indents = make([]string, maxDepth)
+
+func init() {
+	for index := range indents {
+		indents[index] = strings.Repeat("  ", index)
+	}
+}
+
+// PrintChoices print a sequence of choices on a line.
+func PrintChoices(depth int, tag string, choices []Choice) {
+	fmt.Printf("%s%s @[ ", indents[depth], tag)
+	for _, choice := range choices {
+		switch choice := choice.(type) {
+		case *SumChoice:
+			fmt.Printf("%d ", choice.Index)
+		case *StructChoice:
+			var ix string
+			if len(choice.Index) == 0 {
+				ix = "<anonymous>"
+			} else {
+				ix = choice.Index
+			}
+
+			fmt.Printf("%v ", ix)
+		default:
+			glog.Fatal("inconceivable")
+		}
+	}
+
+	fmt.Println("]")
+}
+
+// Print the mapping.
+func (m *MappedField) Print(depth int) {
+	var name string
+	if len(m.Name) > 0 {
+		name = m.Name
+	} else {
+		name = "<anonymous>"
+	}
+	PrintChoices(depth, name, m.SourcePath)
+	if m.Atom == nil {
+		fmt.Printf("%s<Identity>\n", indents[depth])
+	} else {
+		m.Atom.Print(depth + 1)
+	}
+}
+
+// Print the mapping.
+func (m *MappedStruct) Print(depth int) {
+	PrintChoices(depth, "struct", m.SourcePath)
+	for _, field := range m.Fields {
+		field.Print(depth + 1)
+	}
+}
+
+// Print the mapping.
+func (m *MappedSlice) Print(depth int) {
+	fmt.Printf("%sslice\n", indents[depth])
+	if m.Elem == nil {
+		fmt.Printf("%s<Identity>\n", indents[depth])
+	} else {
+		m.Elem.Print(depth)
+	}
+}
+
+// Print the mapping.
+func (m *MappedMap) Print(depth int) {
+	fmt.Printf("%smap\n", indents[depth])
+	if m.Value == nil {
+		fmt.Printf("%s<Identity>\n", indents[depth])
+	} else {
+		m.Value.Print(depth)
+	}
+}

--- a/mapping/typewrapper.go
+++ b/mapping/typewrapper.go
@@ -1,0 +1,204 @@
+package mapping
+
+import (
+	"go/ast"
+
+	"github.com/golang/glog"
+	"github.com/koki/shorthand/inspect"
+	"github.com/kr/pretty"
+)
+
+// TypeWrapper wrapper for TypeIdents.
+type TypeWrapper interface {
+	getWrapper() TypeWrapper
+}
+
+// TypeIdent is a fully qualified type identifier.
+type TypeIdent struct {
+	// PkgPath is an empty string for built-in types like "string"
+	PkgPath string
+	// Name e.g. "string", "Pod"
+	Name string
+	// Definition of the type (if not built-in).
+	Definition TypeDefinition
+}
+
+// Map is map[Key]Value
+type Map struct {
+	Key   TypeWrapper
+	Value TypeWrapper
+}
+
+// Slice is []Value
+type Slice struct {
+	Value TypeWrapper
+}
+
+// Pointer is *Value
+type Pointer struct {
+	Value TypeWrapper
+}
+
+type TypeDefinition interface {
+	getTypeDefinition() TypeDefinition
+}
+
+type WrapperDefinition struct {
+	Value TypeWrapper
+}
+
+type Field struct {
+	Name string
+	Type TypeWrapper
+}
+
+type StructDefinition struct {
+	Fields []Field
+}
+
+// RootType the type at the focus of the context.
+func RootType(context *inspect.Context) TypeWrapper {
+	return &TypeIdent{PkgPath: context.PackagePath(),
+		Name: context.TypeSpec.Name.Name}
+}
+
+// ParseTypeExpr converts Go AST to a simplified (limited) representation.
+func ParseTypeExpr(context *inspect.Context, typeExpr ast.Expr) TypeWrapper {
+	switch typeExpr := typeExpr.(type) {
+	// Ident and Selector are base cases because this is about names.
+	case *ast.Ident:
+		if typeExpr.Obj != nil {
+			return &TypeIdent{PkgPath: context.PackagePath(),
+				Name: typeExpr.Name}
+		}
+
+		// If no linked ast.Object, then it's a built-in type.
+		return &TypeIdent{PkgPath: "",
+			Name: typeExpr.Name}
+	case *ast.SelectorExpr:
+		selectedContext := context.RefocusedWithSelector(typeExpr)
+		return &TypeIdent{PkgPath: selectedContext.PackagePath(),
+			Name: selectedContext.TypeSpec.Name.Name}
+	// These are the recursive cases.
+	case *ast.ParenExpr:
+		return ParseTypeExpr(context, typeExpr.X)
+	case *ast.StarExpr:
+		return &Pointer{Value: ParseTypeExpr(context, typeExpr.X)}
+	case *ast.ArrayType:
+		if typeExpr.Len == nil {
+			return &Slice{Value: ParseTypeExpr(
+				context,
+				typeExpr.Elt)}
+		}
+	case *ast.MapType:
+		return &Map{
+			Key:   ParseTypeExpr(context, typeExpr.Key),
+			Value: ParseTypeExpr(context, typeExpr.Value)}
+	}
+
+	glog.Fatal(pretty.Printf(
+		"unsupported type expr (%# v)",
+		typeExpr))
+	return nil
+}
+
+// DeepParseType is like ParseTypeExpr except it fills in TypeIdent.Definition
+func DeepParseType(context *inspect.Context) TypeWrapper {
+	return &TypeIdent{PkgPath: context.PackagePath(),
+		Name:       context.TypeSpec.Name.Name,
+		Definition: ParseTypeDefinition(context)}
+}
+
+func DeepParseTypeExpr(context *inspect.Context, typeExpr ast.Expr) TypeWrapper {
+	switch typeExpr := typeExpr.(type) {
+	// Ident and Selector are base cases because this is about names.
+	case *ast.Ident:
+		if typeExpr.Obj != nil {
+			typeSpec := inspect.IdentTypeSpec(typeExpr)
+			if typeSpec == nil {
+				glog.Fatal(pretty.Sprintf("expected typeSpec in (%# v)", typeExpr))
+			}
+
+			newContext := context.RefocusedWithinPackage(typeSpec)
+			return &TypeIdent{PkgPath: context.PackagePath(),
+				Name:       typeExpr.Name,
+				Definition: ParseTypeDefinition(newContext)}
+		}
+
+		// If no linked ast.Object, then it's a built-in type.
+		return &TypeIdent{PkgPath: "",
+			Name: typeExpr.Name}
+	case *ast.SelectorExpr:
+		selectedContext := context.RefocusedWithSelector(typeExpr)
+		return &TypeIdent{PkgPath: selectedContext.PackagePath(),
+			Name:       selectedContext.TypeSpec.Name.Name,
+			Definition: ParseTypeDefinition(selectedContext)}
+	// These are the recursive cases.
+	case *ast.ParenExpr:
+		return DeepParseTypeExpr(context, typeExpr.X)
+	case *ast.StarExpr:
+		return &Pointer{Value: DeepParseTypeExpr(context, typeExpr.X)}
+	case *ast.ArrayType:
+		if typeExpr.Len == nil {
+			return &Slice{Value: DeepParseTypeExpr(
+				context,
+				typeExpr.Elt)}
+		}
+	case *ast.MapType:
+		return &Map{
+			Key:   DeepParseTypeExpr(context, typeExpr.Key),
+			Value: DeepParseTypeExpr(context, typeExpr.Value)}
+	}
+
+	glog.Fatal(pretty.Printf(
+		"unsupported type expr (%# v)",
+		typeExpr))
+	return nil
+}
+
+func ParseTypeDefinition(context *inspect.Context) TypeDefinition {
+	switch typeExpr := context.TypeSpec.Type.(type) {
+	case *ast.StructType:
+		fields := []Field{}
+		for _, field := range typeExpr.Fields.List {
+			fieldType := DeepParseTypeExpr(context, field.Type)
+			for _, fieldIdent := range field.Names {
+				var fieldName string
+				if fieldIdent != nil {
+					fieldName = fieldIdent.Name
+				}
+
+				fields = append(fields, Field{
+					Name: fieldName, Type: fieldType})
+			}
+		}
+
+		return &StructDefinition{Fields: fields}
+	default:
+		return &WrapperDefinition{Value: ParseTypeExpr(context, typeExpr)}
+	}
+}
+
+func (d *WrapperDefinition) getTypeDefinition() TypeDefinition {
+	return d
+}
+
+func (d *StructDefinition) getTypeDefinition() TypeDefinition {
+	return d
+}
+
+func (t *TypeIdent) getWrapper() TypeWrapper {
+	return t
+}
+
+func (t *Map) getWrapper() TypeWrapper {
+	return t
+}
+
+func (t *Slice) getWrapper() TypeWrapper {
+	return t
+}
+
+func (t *Pointer) getWrapper() TypeWrapper {
+	return t
+}

--- a/mapping/typewrapper.go
+++ b/mapping/typewrapper.go
@@ -34,9 +34,14 @@ type Slice struct {
 	Value TypeWrapper
 }
 
-// Pointer is *Value
-type Pointer struct {
-	Value TypeWrapper
+// TODO: Pointer is actually a subset of Sum (not implemented).
+// We can implement Sum types using interfaces.
+type Sum struct {
+	Choices []TypeWrapper
+}
+
+func PointerOf(t TypeWrapper) *Sum {
+	return &Sum{[]TypeWrapper{nil, t}}
 }
 
 type TypeDefinition interface {
@@ -83,7 +88,7 @@ func ParseTypeExpr(context *inspect.Context, typeExpr ast.Expr) TypeWrapper {
 	case *ast.ParenExpr:
 		return ParseTypeExpr(context, typeExpr.X)
 	case *ast.StarExpr:
-		return &Pointer{Value: ParseTypeExpr(context, typeExpr.X)}
+		return PointerOf(ParseTypeExpr(context, typeExpr.X))
 	case *ast.ArrayType:
 		if typeExpr.Len == nil {
 			return &Slice{Value: ParseTypeExpr(
@@ -199,6 +204,6 @@ func (t *Slice) getWrapper() TypeWrapper {
 	return t
 }
 
-func (t *Pointer) getWrapper() TypeWrapper {
+func (t *Sum) getWrapper() TypeWrapper {
 	return t
 }


### PR DESCRIPTION
mapping/mapping.go defines types that specify a mapping from an existing type to a new "Mapped" type.

mapping/typewrapper.go defines types that limit the AST to just the parts shorthand cares about.

@wlan0 